### PR TITLE
Dump mysql as binary output

### DIFF
--- a/abiquo_sos.py
+++ b/abiquo_sos.py
@@ -82,9 +82,11 @@ class abiquo_sos(Plugin, RedHatPlugin):
                     dbPassword = xml_params['password']
                     dbHost = self.find_between(xml_params['url'], 'mysql://', ':')
                     dbPort = self.find_between(xml_params['url'], dbHost + ':', '/')
-                    dbSchema = 'kinton'
-                self.add_cmd_output("mysqldump --routines --triggers -h " + dbHost + " -P " + dbPort + " -u " + dbUsername + " --password=" + dbPassword + " " + dbSchema, suggest_filename="kinton_dump.sql")
-                self.add_cmd_output("mysqldump --routines --triggers -h " + dbHost + " -P " + dbPort + " -u " + dbUsername + " --password=" + dbPassword + " kinton_accounting --ignore-table=kinton_accounting.accounting_event_detail", suggest_filename="kinton_dump_ignore_accounting_event_detail.sql")
+                dump = 'mysqldump --routines --triggers -h %s -P %s -u %s --password="%s" %s'
+                dump_kinton     = dump % (dbHost, dbPort, dbUsername, dbPassword, "kinton")
+                dump_accounting = dump % (dbHost, dbPort, dbUsername, dbPassword, "kinton_accounting --ignore-table=kinton_accounting.accounting_event_detail")
+                self.add_cmd_output("sh -c '%s | gzip'" % (dump_kinton)    , binary=True, suggest_filename="kinton_dump.sql.gz")
+                self.add_cmd_output("sh -c '%s | gzip'" % (dump_accounting), binary=True, suggest_filename="accounting_dump.sql.gz")
 
         # rabbitmq queues status
         if self.is_installed("rabbitmq-server"):


### PR DESCRIPTION
This prevents the sosreport from parsing the output as a string to
convert it to UTF-8. BTW, it also reduces the space needed to create a
sosreport.

Fixes #10